### PR TITLE
Avoid thin splitter

### DIFF
--- a/src/content/httprequester-window.xul
+++ b/src/content/httprequester-window.xul
@@ -200,56 +200,50 @@
    <!-- draggable splitter between left/right request/response sections -->
    <splitter collapse="after" resizeAfter="farthest">
    </splitter>
+   <tabbox id="reponse-tabs" flex="2">
+     <tabs>
+       <tab>Body</tab>
+       <tab>Headers</tab>
+     </tabs>
+     <tabpanels flex="2">
+       <!-- response area -->
+       <vbox  style="overflow: auto" flex="100">
+         <description id="title"/>
+         <hbox>
+           <label id="statusHeading" value="Status:"/>
+           <label id="code" value=""/>
+           <spacer flex="1"/>
 
-    <!-- response area -->
-	<groupbox flex="100" >
-      	<caption label="Response"/>
-		<vbox style="overflow: auto" flex="100">
-           <vbox  style="overflow: auto" flex="100">
-              <description id="title"/>
-              <hbox>
-                 <label id="statusHeading" value="Status:"/>
-                 <label id="code" value=""/>
-                 <spacer flex="1"/>
+           <radiogroup id="responseRenderType" onselect="App.responseRenderTypeChanged()">
+             <row align="center">
+               <radio group="position" label="Browser" value="0"  />
+               <radio group="position" label="Text" value="1" />
+             </row>
+           </radiogroup>
 
-                  <radiogroup id="responseRenderType" onselect="App.responseRenderTypeChanged()">
-                      <row align="center">
-                          <radio group="position" label="Browser" value="0"  />
-                          <radio group="position" label="Text" value="1" />
-                      </row>
-                  </radiogroup>
+           <checkbox id="prettyPrint" label="Pretty format"
+             autocheck="false" oncommand="App.togglePrettyPrint();" />
+           <label align="end"  class="small-margin, text-link" value="View raw transaction" onclick="App.viewRawRequest();" crop="end"/>
+         </hbox>
+         <!--<separator orient="horizontal" class="groove"/>-->
+         <vbox minheight="100px" flex="3">
+           <textbox id="response-content" multiline="true" flex="3"/>
+           <iframe id="browserIframe" type="content" flex="1" />
+         </vbox>
+       </vbox>
 
-                  <checkbox id="prettyPrint" label="Pretty format"
-                            autocheck="false" oncommand="App.togglePrettyPrint();" />
-                 <label align="end"  class="small-margin, text-link" value="View raw transaction" onclick="App.viewRawRequest();" crop="end"/>
-              </hbox>
-              <!--<separator orient="horizontal" class="groove"/>-->
-              <vbox minheight="100px" flex="3">
-                  <textbox id="response-content" multiline="true" flex="3"/>
-                  <iframe id="browserIframe" type="content" flex="1" />
-              </vbox>
-            </vbox>
-
-            <!-- draggable splitter between response content and
-
-
-
-            headers section -->
-            <splitter resizeAfter="flex">
-            </splitter>
-
-            <vbox style="overflow: auto">
-                <caption label="Headers"/>
-	         <grid flex="1">
-	            <columns>
-	               <column/>
-	               <column flex="1"/>
-	            </columns>
-	            <rows id="headers"/>
-	         </grid>
-	      </vbox>
-	   </vbox>
-   </groupbox>
+       <vbox style="overflow: auto">
+         <caption label="Headers"/>
+         <grid flex="1">
+           <columns>
+             <column/>
+             <column flex="1"/>
+           </columns>
+           <rows id="headers"/>
+         </grid>
+       </vbox>
+     </tabpanels>
+   </tabbox>
   
    </hbox>
    <!-- draggable splitter between request/response and History -->

--- a/src/content/httprequester-window.xul
+++ b/src/content/httprequester-window.xul
@@ -247,7 +247,7 @@
   
    </hbox>
    <!-- draggable splitter between request/response and History -->
-   <splitter resizeAfter="flex">
+   <splitter resizeAfter="flex" height="3">
    </splitter>
     <!-- list of requests --> 
 	<vbox style="overflow: auto">


### PR DESCRIPTION
The very very thing splitter that separates panels (body/headers and also request/history) has always annoyed me. It's extremely thin, and it usually takes me a few tens of seconds to pinpoint correctly and drag around (I can't image somebody with actual motor problems!).

I've worked around this by:

Replace the body/headers splitter with a tabset. This also looks tidier and is a bit more consistent with the rest of the layout:

Before:

![before](https://cloud.githubusercontent.com/assets/730811/13197270/7e85953a-d7c7-11e5-871c-092de137b174.png)

After:

![2016-02-20t11 36 20 445234620-03 00](https://cloud.githubusercontent.com/assets/730811/13197271/8635aeb4-d7c7-11e5-9859-2f89bb1f9304.png)
![2016-02-20t11 36 22 230194795-03 00](https://cloud.githubusercontent.com/assets/730811/13197272/8843efd6-d7c7-11e5-9bff-bcd0b8fda76c.png)

I also made the splitter that separates the request from the history panels 3px high, which makes it _a lot_ easier to click/drag.
